### PR TITLE
fix: correct broken GitHub link in documentation

### DIFF
--- a/content/docs/4.0/4-cell-templates/5-ChevronCell.mdx
+++ b/content/docs/4.0/4-cell-templates/5-ChevronCell.mdx
@@ -15,7 +15,7 @@ filtering rows available to display, creating indents).
 
 #### Implementation
 
- - Open `ChevronCell` implementation on <a href="https://github.com/silevis/reactgrid/blob/v4.0.2/src/lib/CellTemplates/ChevronCellTemplate.tsx" target="_blank"> github <i className="fas fa-external-link-alt fa-xs pl-1"></i></a>
+ - Open `ChevronCell` implementation on <a href="https://github.com/silevis/reactgrid/blob/develop/src/lib/CellTemplates/ChevronCellTemplate.tsx" target="_blank"> github <i className="fas fa-external-link-alt fa-xs pl-1"></i></a>
 
 #### Interface declaration 
 

--- a/content/docs/4.0/4-cell-templates/5-ChevronCell.mdx
+++ b/content/docs/4.0/4-cell-templates/5-ChevronCell.mdx
@@ -15,7 +15,7 @@ filtering rows available to display, creating indents).
 
 #### Implementation
 
- - Open `ChevronCell` implementation on <a href="https://github.com/silevis/reactgrid/blob/develop/src/lib/CellTemplates/ChevronCellTemplate.tsx" target="_blank"> github <i className="fas fa-external-link-alt fa-xs pl-1"></i></a>
+ - Open `ChevronCell` implementation on <a href="https://github.com/silevis/reactgrid/blob/v4.1.1/src/lib/CellTemplates/ChevronCellTemplate.tsx" target="_blank"> github <i className="fas fa-external-link-alt fa-xs pl-1"></i></a>
 
 #### Interface declaration 
 


### PR DESCRIPTION
fix: correct broken `GitHub` link in documentation

The documentation contained a broken link pointing to the file on GitHub for ChevronCell implementation.
This commit fixes the link to correctly direct users to the file.

- Updated the GitHub link to point to the correct file.
- Verified that the link now functions as expected.

Closes silevis/reactgrid#246